### PR TITLE
Fix  terminal is not fully functional by adding ncurses as a dependency + fix stdin commands not being converted

### DIFF
--- a/buildenv
+++ b/buildenv
@@ -30,9 +30,10 @@ export ZOPEN_TYPE="TARBALL"
 # Many packages will require basic tools like m4, make.
 #
 export ZOPEN_TARBALL_URL="http://www.greenwoodsoftware.com/less/less-590.tar.gz"
-export ZOPEN_TARBALL_DEPS="make curl gzip" 
+export ZOPEN_TARBALL_DEPS="make curl gzip tar ncurses" 
 
 export LDFLAGS="-Wl,edit=no"
 export ZOPEN_EXTRA_CFLAGS="-O2 -DPATH_MAX=2048"
 
 export ZOPEN_INSTALL_OPTS="install PREFIX=\$ZOPEN_INSTALL_DIR"
+export ZOPEN_CHECK="skip"

--- a/buildenv
+++ b/buildenv
@@ -30,7 +30,7 @@ export ZOPEN_TYPE="TARBALL"
 # Many packages will require basic tools like m4, make.
 #
 export ZOPEN_TARBALL_URL="http://www.greenwoodsoftware.com/less/less-608.tar.gz"
-export ZOPEN_TARBALL_DEPS="make curl gzip tar ncurses" 
+export ZOPEN_TARBALL_DEPS="make curl gzip tar ncurses zoslib" 
 
 export LDFLAGS="-Wl,edit=no"
 export ZOPEN_EXTRA_CFLAGS="-O2 -DPATH_MAX=1024"

--- a/patches/PR1.patch
+++ b/patches/PR1.patch
@@ -1,0 +1,15 @@
+diff --git a/ttyin.c b/ttyin.c
+index 4be4527..5b5bbb0 100644
+--- a/ttyin.c
++++ b/ttyin.c
+@@ -76,6 +76,10 @@ open_tty(VOID_PARAM)
+ 	if (fd < 0)
+ 		fd = 2;
+ 	return fd;
++#ifdef __MVS__
++  struct f_cnvrt cvtreq = {SETCVTON, 0, 1047};
++  fcntl(fd, F_CONTROL_CVT, &cvtreq);
++#endif
+ }
+ #endif /* MSDOS_COMPILER */
+ 


### PR DESCRIPTION
Fixes the following warning by linking the ncurses (which comes with a terminal database)
```
[ITODORO@ZOSCAN2B ~/zopen/prod/less/bin]$ ./less
WARNING: terminal is not fully functional
Missing filename ("less --help" for help)
```