### PR TITLE
Default charset to utf-8 so that it renders utf-8 characters properly

### DIFF
--- a/patches/charset.c.patch
+++ b/patches/charset.c.patch
@@ -1,18 +1,31 @@
 diff --git a/charset.c b/charset.c
-index 5e9a2d6..60861d0 100644
+index 5e9a2d6..f481d90 100644
 --- a/charset.c
 +++ b/charset.c
-@@ -389,6 +389,13 @@ set_charset(VOID_PARAM)
+@@ -376,19 +376,25 @@ set_charset(VOID_PARAM)
+ 	 * rather than from predefined charset entry.
+ 	 */
+ 	ilocale();
++#ifdef __MVS__
++	/*
++	 * z/OS Locale does not properly support UTF-8. Default to "utf-8".
++	 */
++	(void) icharset("utf-8", 1);
++#endif
+ #else
+ #if MSDOS_COMPILER
+ 	/*
+ 	 * Default to "dos".
+ 	 */
+ 	(void) icharset("dos", 1);
+-#else
+ 	/*
+ 	 * Default to "latin1".
+ 	 */
  	(void) icharset("latin1", 1);
  #endif
  #endif
 +
-+#ifdef __MVS__
-+	/*
-+	 * Default to "utf-8".
-+	 */
-+	(void) icharset("utf-8", 1);
-+#endif
  }
  
  /*

--- a/patches/charset.c.patch
+++ b/patches/charset.c.patch
@@ -1,5 +1,5 @@
 diff --git a/charset.c b/charset.c
-index 5e9a2d6..12fdfd9 100644
+index 5e9a2d6..60861d0 100644
 --- a/charset.c
 +++ b/charset.c
 @@ -389,6 +389,13 @@ set_charset(VOID_PARAM)
@@ -7,7 +7,7 @@ index 5e9a2d6..12fdfd9 100644
  #endif
  #endif
 +
-+#if __MVS__
++#ifdef __MVS__
 +	/*
 +	 * Default to "utf-8".
 +	 */

--- a/patches/charset.c.patch
+++ b/patches/charset.c.patch
@@ -1,0 +1,18 @@
+diff --git a/charset.c b/charset.c
+index 5e9a2d6..12fdfd9 100644
+--- a/charset.c
++++ b/charset.c
+@@ -389,6 +389,13 @@ set_charset(VOID_PARAM)
+ 	(void) icharset("latin1", 1);
+ #endif
+ #endif
++
++#if __MVS__
++	/*
++	 * Default to "utf-8".
++	 */
++	(void) icharset("utf-8", 1);
++#endif
+ }
+ 
+ /*


### PR DESCRIPTION
Resolves: https://github.com/ZOSOpenTools/lessport/issues/10.

The default codeset is ASCII, so utf-8 characters don't get displayed properly. 

./less ../GG.echo
H¢¬

If less is used as the pager for Git, then it also resolves: https://github.com/ZOSOpenTools/gitport/issues/65.

Another way to fix it is to set `LANG=en_CA.UTF-8` but that could have other repercussions.