### PR TITLE
Version bump to less-643

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,15 @@
 .vscode
 install
-less-608
+less-*
 log
+
+# Vim swap files
+[._]*.s[a-v][a-z]
+[._]*.sw[a-p]
+[._]s[a-rt-v][a-z]
+[._]ss[a-gi-z]
+[._]sw[a-p]
+
+# Vim backup files
+*~
+

--- a/buildenv
+++ b/buildenv
@@ -38,6 +38,8 @@ export ZOPEN_CHECK="./basictest.sh"
 export ZOPEN_CHECK_OPTS=''
 export ZOPEN_COMP=CLANG
 
+export ZOPEN_CLEAN="true"
+
 zopen_check_results()
 {
 # Example check log file:

--- a/buildenv
+++ b/buildenv
@@ -28,7 +28,7 @@ export ZOPEN_TYPE="TARBALL"
 #  - git: required by build.sh to be able to apply patches
 # Many packages will require basic tools like m4, make.
 #
-export ZOPEN_TARBALL_URL="http://www.greenwoodsoftware.com/less/less-632.tar.gz"
+export ZOPEN_TARBALL_URL="http://www.greenwoodsoftware.com/less/less-643.tar.gz"
 export ZOPEN_TARBALL_DEPS="make curl gzip tar ncurses zoslib"
 
 export ZOPEN_EXTRA_CFLAGS="-DPATH_MAX=1024"

--- a/patches/TEST.patch
+++ b/patches/TEST.patch
@@ -6,7 +6,7 @@ index 0000000..4d28fca
 @@ -0,0 +1,8 @@
 +#!/bin/sh
 +actual=$(./less --version | head -1)
-+expected='less 632 (POSIX regular expressions)'
++expected='less 643 (POSIX regular expressions)'
 +if [ "${actual}x" != "${expected}x" ]; then
 +  echo 'less failed'
 +else


### PR DESCRIPTION
The stable version of `less` has been updated to version 643.  This PR pulls the new version, as well as adding build tweaks so it can continue to compile in the latest version of `zopen`.